### PR TITLE
MOB-298

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
-github "Alamofire/Alamofire" "4.6.0"
+github "Alamofire/Alamofire" "4.7.0"
 github "Quick/Nimble" "v7.0.3"
 github "Quick/Quick" "v1.2.0"

--- a/LiCoreSDK.xcodeproj/project.pbxproj
+++ b/LiCoreSDK.xcodeproj/project.pbxproj
@@ -45,8 +45,6 @@
 		2A682E4D1EADBD85004EDEAF /* LiAuthManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A682E4B1EADBD85004EDEAF /* LiAuthManager.swift */; };
 		2A69BEB81FAC643C004682A6 /* LiRestResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A69BEB71FAC643C004682A6 /* LiRestResponse.swift */; };
 		2A69BEB91FAC643C004682A6 /* LiRestResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A69BEB71FAC643C004682A6 /* LiRestResponse.swift */; };
-		2A7943AB1EA89900009ED79B /* Nimble.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 2AD700FF1E94FD1E0045D9EC /* Nimble.framework */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
-		2A7943AC1EA89900009ED79B /* Quick.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 2AD701001E94FD1E0045D9EC /* Quick.framework */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		2A7943CD1EA89966009ED79B /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2A7943B61EA89959009ED79B /* Nimble.framework */; };
 		2A7943CE1EA89976009ED79B /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2A7943B81EA89959009ED79B /* Quick.framework */; };
 		2A7943D81EA899E5009ED79B /* Alamofire.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2A7943D21EA899D9009ED79B /* Alamofire.framework */; };
@@ -91,6 +89,8 @@
 		2AAAD9BC1E9C9BE600E9C40F /* LiMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AAAD9BA1E9C9BE600E9C40F /* LiMessage.swift */; };
 		2AAEC2D61F398A820094295A /* LiImageUpload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AAEC2D51F398A820094295A /* LiImageUpload.swift */; };
 		2AAEC2D71F398A880094295A /* LiImageUpload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AAEC2D51F398A820094295A /* LiImageUpload.swift */; };
+		2AC0B08B2064B1D900D6750C /* LiSDKManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AC0B08A2064B1D900D6750C /* LiSDKManagerTests.swift */; };
+		2AC66CB02068C30700ABFBA9 /* LiAppCredentialsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AC66CAF2068C30700ABFBA9 /* LiAppCredentialsTests.swift */; };
 		2ACD22802007AFDE00BD1961 /* LiRanking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2ACD227F2007AFDE00BD1961 /* LiRanking.swift */; };
 		2ACD22812007AFDE00BD1961 /* LiRanking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2ACD227F2007AFDE00BD1961 /* LiRanking.swift */; };
 		2AD4E2601FB5989600184F3E /* LiQueryClause.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AD4E25F1FB5989600184F3E /* LiQueryClause.swift */; };
@@ -139,8 +139,6 @@
 			dstSubfolderSpec = 10;
 			files = (
 				2A8BF1F41EA9E2C100C3CF18 /* Alamofire.framework in CopyFiles */,
-				2A7943AB1EA89900009ED79B /* Nimble.framework in CopyFiles */,
-				2A7943AC1EA89900009ED79B /* Quick.framework in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 1;
 		};
@@ -226,10 +224,86 @@
 		2AAAD9B71E9C999C00E9C40F /* LiAvatar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LiAvatar.swift; sourceTree = "<group>"; };
 		2AAAD9BA1E9C9BE600E9C40F /* LiMessage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LiMessage.swift; sourceTree = "<group>"; };
 		2AAEC2D51F398A820094295A /* LiImageUpload.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LiImageUpload.swift; sourceTree = "<group>"; };
+		2AC0B08A2064B1D900D6750C /* LiSDKManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiSDKManagerTests.swift; sourceTree = "<group>"; };
+		2AC0B08F2064D04500D6750C /* .Alamofire.version */ = {isa = PBXFileReference; lastKnownFileType = text; path = .Alamofire.version; sourceTree = "<group>"; };
+		2AC0B0902064D04500D6750C /* .Nimble.version */ = {isa = PBXFileReference; lastKnownFileType = text; path = .Nimble.version; sourceTree = "<group>"; };
+		2AC0B0912064D04500D6750C /* .OHHTTPStubs.version */ = {isa = PBXFileReference; lastKnownFileType = text; path = .OHHTTPStubs.version; sourceTree = "<group>"; };
+		2AC0B0922064D04500D6750C /* .Quick.version */ = {isa = PBXFileReference; lastKnownFileType = text; path = .Quick.version; sourceTree = "<group>"; };
+		2AC0B0932064D04500D6750C /* .SwiftyBeaver.version */ = {isa = PBXFileReference; lastKnownFileType = text; path = .SwiftyBeaver.version; sourceTree = "<group>"; };
+		2AC0B0942064D04500D6750C /* .XCGLogger.version */ = {isa = PBXFileReference; lastKnownFileType = text; path = .XCGLogger.version; sourceTree = "<group>"; };
+		2AC0B0962064D04500D6750C /* 00D42C87-4096-36A9-B224-E6E692A8DD15.bcsymbolmap */ = {isa = PBXFileReference; lastKnownFileType = text; path = "00D42C87-4096-36A9-B224-E6E692A8DD15.bcsymbolmap"; sourceTree = "<group>"; };
+		2AC0B0972064D04500D6750C /* 08A025E6-F3FB-3C03-995C-017F019C205A.bcsymbolmap */ = {isa = PBXFileReference; lastKnownFileType = text; path = "08A025E6-F3FB-3C03-995C-017F019C205A.bcsymbolmap"; sourceTree = "<group>"; };
+		2AC0B0982064D04500D6750C /* 09E9D631-D0A7-35D9-815B-FDF10DCD5F80.bcsymbolmap */ = {isa = PBXFileReference; lastKnownFileType = text; path = "09E9D631-D0A7-35D9-815B-FDF10DCD5F80.bcsymbolmap"; sourceTree = "<group>"; };
+		2AC0B0992064D04500D6750C /* 0C46A569-AA2F-328C-AD44-89C8E6F1CB13.bcsymbolmap */ = {isa = PBXFileReference; lastKnownFileType = text; path = "0C46A569-AA2F-328C-AD44-89C8E6F1CB13.bcsymbolmap"; sourceTree = "<group>"; };
+		2AC0B09A2064D04500D6750C /* 0FDE8007-58C3-31CE-A3AF-1EB7108A6919.bcsymbolmap */ = {isa = PBXFileReference; lastKnownFileType = text; path = "0FDE8007-58C3-31CE-A3AF-1EB7108A6919.bcsymbolmap"; sourceTree = "<group>"; };
+		2AC0B09B2064D04500D6750C /* 1175C56E-92F6-3FD3-93D5-FCBF6F9BBB25.bcsymbolmap */ = {isa = PBXFileReference; lastKnownFileType = text; path = "1175C56E-92F6-3FD3-93D5-FCBF6F9BBB25.bcsymbolmap"; sourceTree = "<group>"; };
+		2AC0B09C2064D04500D6750C /* 11D39017-F57E-3FCE-B9E7-3146628BCC3F.bcsymbolmap */ = {isa = PBXFileReference; lastKnownFileType = text; path = "11D39017-F57E-3FCE-B9E7-3146628BCC3F.bcsymbolmap"; sourceTree = "<group>"; };
+		2AC0B09D2064D04500D6750C /* 44A15C13-DDD3-3905-BB8F-4915B910F583.bcsymbolmap */ = {isa = PBXFileReference; lastKnownFileType = text; path = "44A15C13-DDD3-3905-BB8F-4915B910F583.bcsymbolmap"; sourceTree = "<group>"; };
+		2AC0B09E2064D04500D6750C /* 460310F1-0A27-3940-9F81-A1BC75143F6A.bcsymbolmap */ = {isa = PBXFileReference; lastKnownFileType = text; path = "460310F1-0A27-3940-9F81-A1BC75143F6A.bcsymbolmap"; sourceTree = "<group>"; };
+		2AC0B09F2064D04500D6750C /* 51C5AEDD-8DB1-39DE-A505-B12AD8F4FCE9.bcsymbolmap */ = {isa = PBXFileReference; lastKnownFileType = text; path = "51C5AEDD-8DB1-39DE-A505-B12AD8F4FCE9.bcsymbolmap"; sourceTree = "<group>"; };
+		2AC0B0A02064D04500D6750C /* 5AE5A856-46AF-3C5A-A90F-51C6B100E026.bcsymbolmap */ = {isa = PBXFileReference; lastKnownFileType = text; path = "5AE5A856-46AF-3C5A-A90F-51C6B100E026.bcsymbolmap"; sourceTree = "<group>"; };
+		2AC0B0A12064D04500D6750C /* 6AF07053-16A6-3CCB-89DA-17D718D04F78.bcsymbolmap */ = {isa = PBXFileReference; lastKnownFileType = text; path = "6AF07053-16A6-3CCB-89DA-17D718D04F78.bcsymbolmap"; sourceTree = "<group>"; };
+		2AC0B0A22064D04500D6750C /* 7A42645E-B606-3125-B34E-5B456F9403A9.bcsymbolmap */ = {isa = PBXFileReference; lastKnownFileType = text; path = "7A42645E-B606-3125-B34E-5B456F9403A9.bcsymbolmap"; sourceTree = "<group>"; };
+		2AC0B0A32064D04500D6750C /* 7C1220F0-2F99-3547-83DD-50B019028D20.bcsymbolmap */ = {isa = PBXFileReference; lastKnownFileType = text; path = "7C1220F0-2F99-3547-83DD-50B019028D20.bcsymbolmap"; sourceTree = "<group>"; };
+		2AC0B0A42064D04500D6750C /* 7E14F66C-EB97-3481-81DE-73EF57585BB1.bcsymbolmap */ = {isa = PBXFileReference; lastKnownFileType = text; path = "7E14F66C-EB97-3481-81DE-73EF57585BB1.bcsymbolmap"; sourceTree = "<group>"; };
+		2AC0B0A52064D04500D6750C /* 7F5EF0AF-A805-348B-9500-68929C70C924.bcsymbolmap */ = {isa = PBXFileReference; lastKnownFileType = text; path = "7F5EF0AF-A805-348B-9500-68929C70C924.bcsymbolmap"; sourceTree = "<group>"; };
+		2AC0B0A62064D04500D6750C /* 960B0A79-F552-35D1-8CBE-0B9F079E1731.bcsymbolmap */ = {isa = PBXFileReference; lastKnownFileType = text; path = "960B0A79-F552-35D1-8CBE-0B9F079E1731.bcsymbolmap"; sourceTree = "<group>"; };
+		2AC0B0A72064D04500D6750C /* 9B5FEEDB-6807-39F1-B585-0190C0A21196.bcsymbolmap */ = {isa = PBXFileReference; lastKnownFileType = text; path = "9B5FEEDB-6807-39F1-B585-0190C0A21196.bcsymbolmap"; sourceTree = "<group>"; };
+		2AC0B0A82064D04500D6750C /* 9C521878-04FC-3D10-85D3-40D6164821EF.bcsymbolmap */ = {isa = PBXFileReference; lastKnownFileType = text; path = "9C521878-04FC-3D10-85D3-40D6164821EF.bcsymbolmap"; sourceTree = "<group>"; };
+		2AC0B0A92064D04500D6750C /* A19109CE-4FF3-349D-A3B6-F385E442CCD3.bcsymbolmap */ = {isa = PBXFileReference; lastKnownFileType = text; path = "A19109CE-4FF3-349D-A3B6-F385E442CCD3.bcsymbolmap"; sourceTree = "<group>"; };
+		2AC0B0AA2064D04500D6750C /* A3F05EC2-3A8F-30E3-974C-79D2EBFD1BF4.bcsymbolmap */ = {isa = PBXFileReference; lastKnownFileType = text; path = "A3F05EC2-3A8F-30E3-974C-79D2EBFD1BF4.bcsymbolmap"; sourceTree = "<group>"; };
+		2AC0B0AB2064D04500D6750C /* A9E88930-17E9-32F6-92ED-F7AA0D50E764.bcsymbolmap */ = {isa = PBXFileReference; lastKnownFileType = text; path = "A9E88930-17E9-32F6-92ED-F7AA0D50E764.bcsymbolmap"; sourceTree = "<group>"; };
+		2AC0B0AC2064D04500D6750C /* AB9B135B-484E-31EA-8ED3-FBA1F40B2197.bcsymbolmap */ = {isa = PBXFileReference; lastKnownFileType = text; path = "AB9B135B-484E-31EA-8ED3-FBA1F40B2197.bcsymbolmap"; sourceTree = "<group>"; };
+		2AC0B0AD2064D04500D6750C /* Alamofire.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Alamofire.framework; sourceTree = "<group>"; };
+		2AC0B0AE2064D04500D6750C /* Alamofire.framework.dSYM */ = {isa = PBXFileReference; lastKnownFileType = wrapper.dsym; path = Alamofire.framework.dSYM; sourceTree = "<group>"; };
+		2AC0B0AF2064D04500D6750C /* B7D02800-4425-392A-BA3F-B7F27069CC8E.bcsymbolmap */ = {isa = PBXFileReference; lastKnownFileType = text; path = "B7D02800-4425-392A-BA3F-B7F27069CC8E.bcsymbolmap"; sourceTree = "<group>"; };
+		2AC0B0B02064D04500D6750C /* B80F15CB-9D18-35EC-BAAF-A6D313348B8B.bcsymbolmap */ = {isa = PBXFileReference; lastKnownFileType = text; path = "B80F15CB-9D18-35EC-BAAF-A6D313348B8B.bcsymbolmap"; sourceTree = "<group>"; };
+		2AC0B0B12064D04500D6750C /* BA41E38A-39F8-3F4B-B94E-52D1EC5C0ED9.bcsymbolmap */ = {isa = PBXFileReference; lastKnownFileType = text; path = "BA41E38A-39F8-3F4B-B94E-52D1EC5C0ED9.bcsymbolmap"; sourceTree = "<group>"; };
+		2AC0B0B22064D04500D6750C /* C0F31DD3-B19A-308E-AA07-C36EB3E92AF4.bcsymbolmap */ = {isa = PBXFileReference; lastKnownFileType = text; path = "C0F31DD3-B19A-308E-AA07-C36EB3E92AF4.bcsymbolmap"; sourceTree = "<group>"; };
+		2AC0B0B32064D04500D6750C /* CB685B90-17AD-3E72-939A-ABA90CCF26A8.bcsymbolmap */ = {isa = PBXFileReference; lastKnownFileType = text; path = "CB685B90-17AD-3E72-939A-ABA90CCF26A8.bcsymbolmap"; sourceTree = "<group>"; };
+		2AC0B0B42064D04500D6750C /* EE319B71-0D5C-3ED7-80D8-E2E2361FE58E.bcsymbolmap */ = {isa = PBXFileReference; lastKnownFileType = text; path = "EE319B71-0D5C-3ED7-80D8-E2E2361FE58E.bcsymbolmap"; sourceTree = "<group>"; };
+		2AC0B0B52064D04500D6750C /* FB1EC4E0-AF20-39D4-90FD-043869F294B1.bcsymbolmap */ = {isa = PBXFileReference; lastKnownFileType = text; path = "FB1EC4E0-AF20-39D4-90FD-043869F294B1.bcsymbolmap"; sourceTree = "<group>"; };
+		2AC0B0B62064D04500D6750C /* LiCoreSDK.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = LiCoreSDK.framework; sourceTree = "<group>"; };
+		2AC0B0B72064D04500D6750C /* LiCoreSDK.framework.dSYM */ = {isa = PBXFileReference; lastKnownFileType = wrapper.dsym; path = LiCoreSDK.framework.dSYM; sourceTree = "<group>"; };
+		2AC0B0B82064D04500D6750C /* LiiOSCoreSDK.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = LiiOSCoreSDK.framework; sourceTree = "<group>"; };
+		2AC0B0B92064D04500D6750C /* LiiOSCoreSDK.framework.dSYM */ = {isa = PBXFileReference; lastKnownFileType = wrapper.dsym; path = LiiOSCoreSDK.framework.dSYM; sourceTree = "<group>"; };
+		2AC0B0BA2064D04500D6750C /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Nimble.framework; sourceTree = "<group>"; };
+		2AC0B0BB2064D04500D6750C /* Nimble.framework.dSYM */ = {isa = PBXFileReference; lastKnownFileType = wrapper.dsym; path = Nimble.framework.dSYM; sourceTree = "<group>"; };
+		2AC0B0BC2064D04500D6750C /* ObjcExceptionBridging.framework.dSYM */ = {isa = PBXFileReference; lastKnownFileType = wrapper.dsym; path = ObjcExceptionBridging.framework.dSYM; sourceTree = "<group>"; };
+		2AC0B0BD2064D04500D6750C /* OHHTTPStubs.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = OHHTTPStubs.framework; sourceTree = "<group>"; };
+		2AC0B0BE2064D04500D6750C /* OHHTTPStubs.framework.dSYM */ = {isa = PBXFileReference; lastKnownFileType = wrapper.dsym; path = OHHTTPStubs.framework.dSYM; sourceTree = "<group>"; };
+		2AC0B0BF2064D04500D6750C /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Quick.framework; sourceTree = "<group>"; };
+		2AC0B0C02064D04500D6750C /* Quick.framework.dSYM */ = {isa = PBXFileReference; lastKnownFileType = wrapper.dsym; path = Quick.framework.dSYM; sourceTree = "<group>"; };
+		2AC0B0C12064D04500D6750C /* SwiftyBeaver.framework.dSYM */ = {isa = PBXFileReference; lastKnownFileType = wrapper.dsym; path = SwiftyBeaver.framework.dSYM; sourceTree = "<group>"; };
+		2AC0B0C22064D04500D6750C /* XCGLogger.framework.dSYM */ = {isa = PBXFileReference; lastKnownFileType = wrapper.dsym; path = XCGLogger.framework.dSYM; sourceTree = "<group>"; };
+		2AC0B0C42064D04500D6750C /* Alamofire.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Alamofire.framework; sourceTree = "<group>"; };
+		2AC0B0C52064D04500D6750C /* Alamofire.framework.dSYM */ = {isa = PBXFileReference; lastKnownFileType = wrapper.dsym; path = Alamofire.framework.dSYM; sourceTree = "<group>"; };
+		2AC0B0C62064D04500D6750C /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Nimble.framework; sourceTree = "<group>"; };
+		2AC0B0C72064D04500D6750C /* Nimble.framework.dSYM */ = {isa = PBXFileReference; lastKnownFileType = wrapper.dsym; path = Nimble.framework.dSYM; sourceTree = "<group>"; };
+		2AC0B0C82064D04500D6750C /* OHHTTPStubs.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = OHHTTPStubs.framework; sourceTree = "<group>"; };
+		2AC0B0C92064D04500D6750C /* OHHTTPStubs.framework.dSYM */ = {isa = PBXFileReference; lastKnownFileType = wrapper.dsym; path = OHHTTPStubs.framework.dSYM; sourceTree = "<group>"; };
+		2AC0B0CA2064D04500D6750C /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Quick.framework; sourceTree = "<group>"; };
+		2AC0B0CB2064D04500D6750C /* Quick.framework.dSYM */ = {isa = PBXFileReference; lastKnownFileType = wrapper.dsym; path = Quick.framework.dSYM; sourceTree = "<group>"; };
+		2AC0B0CD2064D04500D6750C /* 075A0967-F656-36B0-B093-779F7A6A249C.bcsymbolmap */ = {isa = PBXFileReference; lastKnownFileType = text; path = "075A0967-F656-36B0-B093-779F7A6A249C.bcsymbolmap"; sourceTree = "<group>"; };
+		2AC0B0CE2064D04500D6750C /* 097491BC-DFCB-34C1-9E6F-D56B8BA5B342.bcsymbolmap */ = {isa = PBXFileReference; lastKnownFileType = text; path = "097491BC-DFCB-34C1-9E6F-D56B8BA5B342.bcsymbolmap"; sourceTree = "<group>"; };
+		2AC0B0CF2064D04500D6750C /* Alamofire.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Alamofire.framework; sourceTree = "<group>"; };
+		2AC0B0D02064D04500D6750C /* Alamofire.framework.dSYM */ = {isa = PBXFileReference; lastKnownFileType = wrapper.dsym; path = Alamofire.framework.dSYM; sourceTree = "<group>"; };
+		2AC0B0D12064D04500D6750C /* C3DEB4A3-439A-3897-BE34-5D96798C18E4.bcsymbolmap */ = {isa = PBXFileReference; lastKnownFileType = text; path = "C3DEB4A3-439A-3897-BE34-5D96798C18E4.bcsymbolmap"; sourceTree = "<group>"; };
+		2AC0B0D22064D04500D6750C /* CCD1E92C-2147-310A-B774-4E64833C07DD.bcsymbolmap */ = {isa = PBXFileReference; lastKnownFileType = text; path = "CCD1E92C-2147-310A-B774-4E64833C07DD.bcsymbolmap"; sourceTree = "<group>"; };
+		2AC0B0D32064D04500D6750C /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Nimble.framework; sourceTree = "<group>"; };
+		2AC0B0D42064D04500D6750C /* Nimble.framework.dSYM */ = {isa = PBXFileReference; lastKnownFileType = wrapper.dsym; path = Nimble.framework.dSYM; sourceTree = "<group>"; };
+		2AC0B0D52064D04500D6750C /* OHHTTPStubs.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = OHHTTPStubs.framework; sourceTree = "<group>"; };
+		2AC0B0D62064D04500D6750C /* OHHTTPStubs.framework.dSYM */ = {isa = PBXFileReference; lastKnownFileType = wrapper.dsym; path = OHHTTPStubs.framework.dSYM; sourceTree = "<group>"; };
+		2AC0B0D72064D04500D6750C /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Quick.framework; sourceTree = "<group>"; };
+		2AC0B0D82064D04500D6750C /* Quick.framework.dSYM */ = {isa = PBXFileReference; lastKnownFileType = wrapper.dsym; path = Quick.framework.dSYM; sourceTree = "<group>"; };
+		2AC0B0DA2064D04500D6750C /* 3F417BBB-6818-30E3-A57D-C39573010137.bcsymbolmap */ = {isa = PBXFileReference; lastKnownFileType = text; path = "3F417BBB-6818-30E3-A57D-C39573010137.bcsymbolmap"; sourceTree = "<group>"; };
+		2AC0B0DB2064D04500D6750C /* Alamofire.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Alamofire.framework; sourceTree = "<group>"; };
+		2AC0B0DC2064D04500D6750C /* Alamofire.framework.dSYM */ = {isa = PBXFileReference; lastKnownFileType = wrapper.dsym; path = Alamofire.framework.dSYM; sourceTree = "<group>"; };
+		2AC0B0DD2064D04500D6750C /* EC98DF62-6901-3EE5-A7CA-9182E3F8D724.bcsymbolmap */ = {isa = PBXFileReference; lastKnownFileType = text; path = "EC98DF62-6901-3EE5-A7CA-9182E3F8D724.bcsymbolmap"; sourceTree = "<group>"; };
+		2AC0B0DE2064D04500D6750C /* F085824C-E011-3E41-915B-C46A99276594.bcsymbolmap */ = {isa = PBXFileReference; lastKnownFileType = text; path = "F085824C-E011-3E41-915B-C46A99276594.bcsymbolmap"; sourceTree = "<group>"; };
+		2AC66CAF2068C30700ABFBA9 /* LiAppCredentialsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiAppCredentialsTests.swift; sourceTree = "<group>"; };
 		2ACD227F2007AFDE00BD1961 /* LiRanking.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LiRanking.swift; sourceTree = "<group>"; };
 		2AD4E25F1FB5989600184F3E /* LiQueryClause.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LiQueryClause.swift; sourceTree = "<group>"; };
-		2AD700FF1E94FD1E0045D9EC /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = "Pods/../build/Debug-iphoneos/Nimble/Nimble.framework"; sourceTree = "<group>"; };
-		2AD701001E94FD1E0045D9EC /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quick.framework; path = "Pods/../build/Debug-iphoneos/Quick/Quick.framework"; sourceTree = "<group>"; };
 		2AE3898E1FDA9B8000866588 /* LiAppSdkSettings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LiAppSdkSettings.swift; sourceTree = "<group>"; };
 		2AE389941FDE7A3300866588 /* LiAuthState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LiAuthState.swift; sourceTree = "<group>"; };
 		2AE389971FDFCE4A00866588 /* LiSSOAuthResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LiSSOAuthResponse.swift; sourceTree = "<group>"; };
@@ -470,6 +544,122 @@
 			path = Models;
 			sourceTree = "<group>";
 		};
+		2AC0B08E2064D04500D6750C /* Build */ = {
+			isa = PBXGroup;
+			children = (
+				2AC0B08F2064D04500D6750C /* .Alamofire.version */,
+				2AC0B0902064D04500D6750C /* .Nimble.version */,
+				2AC0B0912064D04500D6750C /* .OHHTTPStubs.version */,
+				2AC0B0922064D04500D6750C /* .Quick.version */,
+				2AC0B0932064D04500D6750C /* .SwiftyBeaver.version */,
+				2AC0B0942064D04500D6750C /* .XCGLogger.version */,
+				2AC0B0952064D04500D6750C /* iOS */,
+				2AC0B0C32064D04500D6750C /* Mac */,
+				2AC0B0CC2064D04500D6750C /* tvOS */,
+				2AC0B0D92064D04500D6750C /* watchOS */,
+			);
+			name = Build;
+			path = Carthage/Build;
+			sourceTree = "<group>";
+		};
+		2AC0B0952064D04500D6750C /* iOS */ = {
+			isa = PBXGroup;
+			children = (
+				2AC0B0962064D04500D6750C /* 00D42C87-4096-36A9-B224-E6E692A8DD15.bcsymbolmap */,
+				2AC0B0972064D04500D6750C /* 08A025E6-F3FB-3C03-995C-017F019C205A.bcsymbolmap */,
+				2AC0B0982064D04500D6750C /* 09E9D631-D0A7-35D9-815B-FDF10DCD5F80.bcsymbolmap */,
+				2AC0B0992064D04500D6750C /* 0C46A569-AA2F-328C-AD44-89C8E6F1CB13.bcsymbolmap */,
+				2AC0B09A2064D04500D6750C /* 0FDE8007-58C3-31CE-A3AF-1EB7108A6919.bcsymbolmap */,
+				2AC0B09B2064D04500D6750C /* 1175C56E-92F6-3FD3-93D5-FCBF6F9BBB25.bcsymbolmap */,
+				2AC0B09C2064D04500D6750C /* 11D39017-F57E-3FCE-B9E7-3146628BCC3F.bcsymbolmap */,
+				2AC0B09D2064D04500D6750C /* 44A15C13-DDD3-3905-BB8F-4915B910F583.bcsymbolmap */,
+				2AC0B09E2064D04500D6750C /* 460310F1-0A27-3940-9F81-A1BC75143F6A.bcsymbolmap */,
+				2AC0B09F2064D04500D6750C /* 51C5AEDD-8DB1-39DE-A505-B12AD8F4FCE9.bcsymbolmap */,
+				2AC0B0A02064D04500D6750C /* 5AE5A856-46AF-3C5A-A90F-51C6B100E026.bcsymbolmap */,
+				2AC0B0A12064D04500D6750C /* 6AF07053-16A6-3CCB-89DA-17D718D04F78.bcsymbolmap */,
+				2AC0B0A22064D04500D6750C /* 7A42645E-B606-3125-B34E-5B456F9403A9.bcsymbolmap */,
+				2AC0B0A32064D04500D6750C /* 7C1220F0-2F99-3547-83DD-50B019028D20.bcsymbolmap */,
+				2AC0B0A42064D04500D6750C /* 7E14F66C-EB97-3481-81DE-73EF57585BB1.bcsymbolmap */,
+				2AC0B0A52064D04500D6750C /* 7F5EF0AF-A805-348B-9500-68929C70C924.bcsymbolmap */,
+				2AC0B0A62064D04500D6750C /* 960B0A79-F552-35D1-8CBE-0B9F079E1731.bcsymbolmap */,
+				2AC0B0A72064D04500D6750C /* 9B5FEEDB-6807-39F1-B585-0190C0A21196.bcsymbolmap */,
+				2AC0B0A82064D04500D6750C /* 9C521878-04FC-3D10-85D3-40D6164821EF.bcsymbolmap */,
+				2AC0B0A92064D04500D6750C /* A19109CE-4FF3-349D-A3B6-F385E442CCD3.bcsymbolmap */,
+				2AC0B0AA2064D04500D6750C /* A3F05EC2-3A8F-30E3-974C-79D2EBFD1BF4.bcsymbolmap */,
+				2AC0B0AB2064D04500D6750C /* A9E88930-17E9-32F6-92ED-F7AA0D50E764.bcsymbolmap */,
+				2AC0B0AC2064D04500D6750C /* AB9B135B-484E-31EA-8ED3-FBA1F40B2197.bcsymbolmap */,
+				2AC0B0AD2064D04500D6750C /* Alamofire.framework */,
+				2AC0B0AE2064D04500D6750C /* Alamofire.framework.dSYM */,
+				2AC0B0AF2064D04500D6750C /* B7D02800-4425-392A-BA3F-B7F27069CC8E.bcsymbolmap */,
+				2AC0B0B02064D04500D6750C /* B80F15CB-9D18-35EC-BAAF-A6D313348B8B.bcsymbolmap */,
+				2AC0B0B12064D04500D6750C /* BA41E38A-39F8-3F4B-B94E-52D1EC5C0ED9.bcsymbolmap */,
+				2AC0B0B22064D04500D6750C /* C0F31DD3-B19A-308E-AA07-C36EB3E92AF4.bcsymbolmap */,
+				2AC0B0B32064D04500D6750C /* CB685B90-17AD-3E72-939A-ABA90CCF26A8.bcsymbolmap */,
+				2AC0B0B42064D04500D6750C /* EE319B71-0D5C-3ED7-80D8-E2E2361FE58E.bcsymbolmap */,
+				2AC0B0B52064D04500D6750C /* FB1EC4E0-AF20-39D4-90FD-043869F294B1.bcsymbolmap */,
+				2AC0B0B62064D04500D6750C /* LiCoreSDK.framework */,
+				2AC0B0B72064D04500D6750C /* LiCoreSDK.framework.dSYM */,
+				2AC0B0B82064D04500D6750C /* LiiOSCoreSDK.framework */,
+				2AC0B0B92064D04500D6750C /* LiiOSCoreSDK.framework.dSYM */,
+				2AC0B0BA2064D04500D6750C /* Nimble.framework */,
+				2AC0B0BB2064D04500D6750C /* Nimble.framework.dSYM */,
+				2AC0B0BC2064D04500D6750C /* ObjcExceptionBridging.framework.dSYM */,
+				2AC0B0BD2064D04500D6750C /* OHHTTPStubs.framework */,
+				2AC0B0BE2064D04500D6750C /* OHHTTPStubs.framework.dSYM */,
+				2AC0B0BF2064D04500D6750C /* Quick.framework */,
+				2AC0B0C02064D04500D6750C /* Quick.framework.dSYM */,
+				2AC0B0C12064D04500D6750C /* SwiftyBeaver.framework.dSYM */,
+				2AC0B0C22064D04500D6750C /* XCGLogger.framework.dSYM */,
+			);
+			path = iOS;
+			sourceTree = "<group>";
+		};
+		2AC0B0C32064D04500D6750C /* Mac */ = {
+			isa = PBXGroup;
+			children = (
+				2AC0B0C42064D04500D6750C /* Alamofire.framework */,
+				2AC0B0C52064D04500D6750C /* Alamofire.framework.dSYM */,
+				2AC0B0C62064D04500D6750C /* Nimble.framework */,
+				2AC0B0C72064D04500D6750C /* Nimble.framework.dSYM */,
+				2AC0B0C82064D04500D6750C /* OHHTTPStubs.framework */,
+				2AC0B0C92064D04500D6750C /* OHHTTPStubs.framework.dSYM */,
+				2AC0B0CA2064D04500D6750C /* Quick.framework */,
+				2AC0B0CB2064D04500D6750C /* Quick.framework.dSYM */,
+			);
+			path = Mac;
+			sourceTree = "<group>";
+		};
+		2AC0B0CC2064D04500D6750C /* tvOS */ = {
+			isa = PBXGroup;
+			children = (
+				2AC0B0CD2064D04500D6750C /* 075A0967-F656-36B0-B093-779F7A6A249C.bcsymbolmap */,
+				2AC0B0CE2064D04500D6750C /* 097491BC-DFCB-34C1-9E6F-D56B8BA5B342.bcsymbolmap */,
+				2AC0B0CF2064D04500D6750C /* Alamofire.framework */,
+				2AC0B0D02064D04500D6750C /* Alamofire.framework.dSYM */,
+				2AC0B0D12064D04500D6750C /* C3DEB4A3-439A-3897-BE34-5D96798C18E4.bcsymbolmap */,
+				2AC0B0D22064D04500D6750C /* CCD1E92C-2147-310A-B774-4E64833C07DD.bcsymbolmap */,
+				2AC0B0D32064D04500D6750C /* Nimble.framework */,
+				2AC0B0D42064D04500D6750C /* Nimble.framework.dSYM */,
+				2AC0B0D52064D04500D6750C /* OHHTTPStubs.framework */,
+				2AC0B0D62064D04500D6750C /* OHHTTPStubs.framework.dSYM */,
+				2AC0B0D72064D04500D6750C /* Quick.framework */,
+				2AC0B0D82064D04500D6750C /* Quick.framework.dSYM */,
+			);
+			path = tvOS;
+			sourceTree = "<group>";
+		};
+		2AC0B0D92064D04500D6750C /* watchOS */ = {
+			isa = PBXGroup;
+			children = (
+				2AC0B0DA2064D04500D6750C /* 3F417BBB-6818-30E3-A57D-C39573010137.bcsymbolmap */,
+				2AC0B0DB2064D04500D6750C /* Alamofire.framework */,
+				2AC0B0DC2064D04500D6750C /* Alamofire.framework.dSYM */,
+				2AC0B0DD2064D04500D6750C /* EC98DF62-6901-3EE5-A7CA-9182E3F8D724.bcsymbolmap */,
+				2AC0B0DE2064D04500D6750C /* F085824C-E011-3E41-915B-C46A99276594.bcsymbolmap */,
+			);
+			path = watchOS;
+			sourceTree = "<group>";
+		};
 		2AE876EB1EF28CC300491680 /* Resources */ = {
 			isa = PBXGroup;
 			children = (
@@ -521,6 +711,8 @@
 				2AF040A22005D457000E81F0 /* ModelTests */,
 				2AEAFB7A1E921A4B00514729 /* Info.plist */,
 				2A63415B203EC31A0057D9A3 /* LiClientRequestParamsTests.swift */,
+				2AC0B08A2064B1D900D6750C /* LiSDKManagerTests.swift */,
+				2AC66CAF2068C30700ABFBA9 /* LiAppCredentialsTests.swift */,
 			);
 			path = LiCoreSDKTests;
 			sourceTree = "<group>";
@@ -548,13 +740,12 @@
 		8B55B0B4CC2EAD16F06E4E3E /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				2AC0B08E2064D04500D6750C /* Build */,
 				2A7943CF1EA899D9009ED79B /* iOS */,
 				2A7943AD1EA89959009ED79B /* Build */,
 				2A7943A61EA8983E009ED79B /* Nimble.framework */,
 				2A7943A71EA8983E009ED79B /* Quick.framework */,
 				2A7943A31EA890A5009ED79B /* Alamofire.framework */,
-				2AD700FF1E94FD1E0045D9EC /* Nimble.framework */,
-				2AD701001E94FD1E0045D9EC /* Quick.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -631,7 +822,7 @@
 					};
 					2AEAFB721E921A4B00514729 = {
 						CreatedOnToolsVersion = 8.3;
-						DevelopmentTeam = NNT4YXH3R5;
+						DevelopmentTeam = DD62CH3UG6;
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -790,6 +981,7 @@
 				2A2309BC2007BC84002090D1 /* LiImage.swift in Sources */,
 				2A553C661EB9D186001BF346 /* LiNetworkUtils.swift in Sources */,
 				2A0551131F611156005C356F /* LiBrowse.swift in Sources */,
+				2AC66CB02068C30700ABFBA9 /* LiAppCredentialsTests.swift in Sources */,
 				2A89A2B1201EF87000E3C693 /* KeychainWrapper.swift in Sources */,
 				2AE3899F1FDFE0BB00866588 /* LiAuthRequestStore.swift in Sources */,
 				2A61B50A1F46F4B500C0BDD0 /* LiImageResponse.swift in Sources */,
@@ -801,6 +993,7 @@
 				2A63415C203EC31A0057D9A3 /* LiClientRequestParamsTests.swift in Sources */,
 				2A90749D1EFA632800D4F2AF /* LiClientConfig.swift in Sources */,
 				2A89A2AF201EF87000E3C693 /* KeychainItemAccessibility.swift in Sources */,
+				2AC0B08B2064B1D900D6750C /* LiSDKManagerTests.swift in Sources */,
 				2AA0AA1B1F0A59660044DE45 /* LiMessageMetrics.swift in Sources */,
 				2A553C6B1EBB3F8F001BF346 /* LiBaseError.swift in Sources */,
 				2A9ECDD0200F482C00801C26 /* LiAuthorizationDelegate.swift in Sources */,
@@ -1015,7 +1208,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
-				DEVELOPMENT_TEAM = NNT4YXH3R5;
+				DEVELOPMENT_TEAM = DD62CH3UG6;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
@@ -1035,7 +1228,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
-				DEVELOPMENT_TEAM = NNT4YXH3R5;
+				DEVELOPMENT_TEAM = DD62CH3UG6;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",

--- a/LiCoreSDK/Auth/LiAppCredentials.swift
+++ b/LiCoreSDK/Auth/LiAppCredentials.swift
@@ -18,20 +18,17 @@ import Alamofire
 /**
  This class contains immutable copy of your community app credentials.
 */
-struct LiAppCredentials {
+public struct LiAppCredentials {
     /**
      Client id as set in Community API apps.
-     Default value is read from the application's Info.plist under `LiClientId` key.
     */
     internal let clientId: String
     /**
     Client secret as set in Community API apps.
-    Default value is read from the application's Info.plist under `LiClientSecret` key.
     */
     internal let clientSecret: String
     /**
     Community URL as set in Community API apps.
-    Default value is read from the application's Info.plist under `LiCommunityUrl` key.
     */
     internal let communityURL: String
     ///URL used to make authorization call. It's obtained by appending path to the community url
@@ -40,23 +37,27 @@ struct LiAppCredentials {
     internal let redirectURL: String
     /**
     Tenant Id as set in Community API apps.
-    Default value is read from the application's Info.plist under `LiTenantId` key.
     */
     internal let tenantID: String
     /**
     Api proxy host as set in Community API apps.
-    Default value is read from the application's Info.plist under `LiApiProxyHost` key.
     */
     internal let apiProxyHost: String
     /**
     Client app name as set in Community API apps.
-    Default value is read from the application's Info.plist under `LiClientAppName` key.
     */
     internal let clientAppName: String
     /**
      Creates a new instance of `LiAppCredentials`.
+     
+     - parameter clientId: Client id as set in Community API apps.
+     - parameter clientSecret: Client secret as set in Community API apps.
+     - parameter communityURL: Community URL as set in Community API apps.
+     - parameter tenantID: Tenant Id as set in Community API apps.
+     - parameter apiProxyHost: Api proxy host as set in Community API apps.
+     - parameter clientAppName: Client app name as set in Community API apps.
      */
-    internal init(clientId: String, clientSecret: String, communityURL: String, tenantID: String, apiProxyHost: String, clientAppName: String) {
+    public init(clientId: String, clientSecret: String, communityURL: String, tenantID: String, apiProxyHost: String, clientAppName: String) {
         if clientId == "" {
             fatalError("SDK initalization failed: LiClientId is missing.")
         }
@@ -86,6 +87,7 @@ struct LiAppCredentials {
     }
     /**
      Funtion to return URLRequest that initiates Lithium login.
+     
      - returns: URLRequest containing the url and parameters for login.
  */
     func getURL() throws -> URLRequest {

--- a/LiCoreSDK/Auth/LiAppCredentials.swift
+++ b/LiCoreSDK/Auth/LiAppCredentials.swift
@@ -21,31 +21,31 @@ import Alamofire
 public struct LiAppCredentials {
     /**
      Client id as set in Community API apps.
-    */
+     */
     internal let clientId: String
     /**
-    Client secret as set in Community API apps.
-    */
+     Client secret as set in Community API apps.
+     */
     internal let clientSecret: String
     /**
-    Community URL as set in Community API apps.
-    */
+     Community URL as set in Community API apps.
+     */
     internal let communityURL: String
     ///URL used to make authorization call. It's obtained by appending path to the community url
     internal let authorizeURL: String
     ///URL used as redirect in authorization calls.
     internal let redirectURL: String
     /**
-    Tenant Id as set in Community API apps.
-    */
+     Tenant Id as set in Community API apps.
+     */
     internal let tenantID: String
     /**
-    Api proxy host as set in Community API apps.
-    */
+     Api proxy host as set in Community API apps.
+     */
     internal let apiProxyHost: String
     /**
-    Client app name as set in Community API apps.
-    */
+     Client app name as set in Community API apps.
+     */
     internal let clientAppName: String
     /**
      Creates a new instance of `LiAppCredentials`.
@@ -57,52 +57,30 @@ public struct LiAppCredentials {
      - parameter apiProxyHost: Api proxy host as set in Community API apps.
      - parameter clientAppName: Client app name as set in Community API apps.
      */
-    public init(clientId: String, clientSecret: String, communityURL: String, tenantID: String, apiProxyHost: String, clientAppName: String) {
-        if clientId == "" {
-            fatalError("SDK initalization failed: LiClientId is missing.")
-        }
-        if clientSecret == "" {
-            fatalError("SDK initalization failed: LiClientSecret is missing.")
-        }
-        if communityURL == "" {
-            fatalError("SDK initalization failed: LiCommunityUrl is missing.")
-        }
-        if tenantID == "" {
-            fatalError("SDK initalization failed: LiTenantId is missing.")
-        }
-        if apiProxyHost == "" {
-            fatalError("SDK initalization failed: LiApiProxyHost is missing.")
-        }
-        if clientAppName == "" {
-            fatalError("SDK initalization failed: LiClientAppName is missing.")
-        }
-        self.clientId = clientId
-        self.clientSecret = clientSecret
-        self.communityURL = communityURL
+    public init(clientId: String, clientSecret: String, communityURL: String, tenantID: String, apiProxyHost: String, clientAppName: String) throws {
+        self.clientId = try LiUtils.nonEmptyStringCheck(value: clientId, errorMessage: "SDK initalization failed: clientId cannot be empty.")
+        self.clientSecret = try LiUtils.nonEmptyStringCheck(value: clientSecret, errorMessage: "SDK initalization failed: clientSecret cannot be empty.")
+        self.communityURL = try LiUtils.urlValidation(url: communityURL, message: "SDK initalization failed: communityURL is in invalid format")
+        self.tenantID = try LiUtils.nonEmptyStringCheck(value: tenantID, errorMessage: "SDK initalization failed: tenantID cannot be empty.")
+        self.apiProxyHost = try LiUtils.nonEmptyStringCheck(value: apiProxyHost, errorMessage: "SDK initalization failed: apiProxyHost cannot be empty.")
+        self.clientAppName = try LiUtils.nonEmptyStringCheck(value: clientAppName, errorMessage: "SDK initalization failed: clientAppName cannot be empty.")
         self.authorizeURL = communityURL + "/auth/oauth2/authorize"
         self.redirectURL =  communityURL.components(separatedBy: "//").last!.components(separatedBy: ".").reversed().joined(separator: ".") + "://oauth2callback"
-        self.tenantID = tenantID
-        self.apiProxyHost = apiProxyHost
-        self.clientAppName = clientAppName
     }
     /**
      Funtion to return URLRequest that initiates Lithium login.
      
      - returns: URLRequest containing the url and parameters for login.
- */
+     */
     func getURL() throws -> URLRequest {
-        guard communityURL != "" else {
-            throw LiBaseError(errorMessage: "Invalid LiCommunityUrl", httpCode: 0)
-        }
         guard let url = URL(string: authorizeURL) else {
-            print("SDK initalization failed: invalid LiCommunityUrl.")
             throw LiBaseError(errorMessage: "Invalid LiCommunityUrl", httpCode: 0)
         }
         let urlRequest = URLRequest(url: url)
         let state = String(Date.timeIntervalSinceReferenceDate)
         let parameters = ["response_type": "code", "redirect_uri": redirectURL, "client_id": clientId, "state": state]
         do {
-        let encodedURLRequest = try URLEncoding.queryString.encode(urlRequest, with: parameters)
+            let encodedURLRequest = try URLEncoding.queryString.encode(urlRequest, with: parameters)
             return encodedURLRequest
         } catch let error {
             throw error

--- a/LiCoreSDK/Auth/LiAppCredentials.swift
+++ b/LiCoreSDK/Auth/LiAppCredentials.swift
@@ -58,22 +58,22 @@ struct LiAppCredentials {
      */
     internal init(clientId: String, clientSecret: String, communityURL: String, tenantID: String, apiProxyHost: String, clientAppName: String) {
         if clientId == "" {
-            print("SDK initalization failed: LiClientId is missing.")
+            fatalError("SDK initalization failed: LiClientId is missing.")
         }
         if clientSecret == "" {
-            print("SDK initalization failed: LiClientSecret is missing.")
+            fatalError("SDK initalization failed: LiClientSecret is missing.")
         }
         if communityURL == "" {
-            print("SDK initalization failed: LiCommunityUrl is missing.")
+            fatalError("SDK initalization failed: LiCommunityUrl is missing.")
         }
         if tenantID == "" {
-            print("SDK initalization failed: LiTenantId is missing.")
+            fatalError("SDK initalization failed: LiTenantId is missing.")
         }
         if apiProxyHost == "" {
-            print("SDK initalization failed: LiApiProxyHost is missing.")
+            fatalError("SDK initalization failed: LiApiProxyHost is missing.")
         }
         if clientAppName == "" {
-            print("SDK initalization failed: LiClientAppName is missing.")
+            fatalError("SDK initalization failed: LiClientAppName is missing.")
         }
         self.clientId = clientId
         self.clientSecret = clientSecret

--- a/LiCoreSDK/Managers/LiClientManager.swift
+++ b/LiCoreSDK/Managers/LiClientManager.swift
@@ -27,6 +27,7 @@ public typealias LiErrorResponse = (_ error: Error) -> Void
  Use this class to perform network calls to clients.
  */
 public struct LiClientManager {
+    internal init() {}
     /**
      This method performs network calls to the provided client.
      
@@ -34,7 +35,7 @@ public struct LiClientManager {
      - parameter success:   Closure containing the success response in the form of an array of objects conforming to LiBaseModel protocol from the network call.
      - parameter error:     Closure containing the failure response from the network call.
      */
-    public static func request(client: LiClient, success: @escaping LiSuccessResponse, failure: @escaping LiErrorResponse) {
+    public func request(client: LiClient, success: @escaping LiSuccessResponse, failure: @escaping LiErrorResponse) {
         switch client {
         case .liUploadImageClient:
             LiRestClient.sharedInstance.upload(client: client, success: { (response: LiBaseResponse) in

--- a/LiCoreSDK/Managers/LiSDKManager.swift
+++ b/LiCoreSDK/Managers/LiSDKManager.swift
@@ -46,7 +46,7 @@ public final class LiSDKManager {
                         apiProxyHost = SDKKeys["LiApiProxyHost"]?.trimmingCharacters(in: .whitespaces) ?? ""
                         clientAppName = SDKKeys["LiClientAppName"] ?? "communityId-sdk"
                     } else {
-                        print("SDK initalization failed: LiAPICredentials are missing.")
+                        fatalError("SDK initalization failed: LiAPICredentials are missing.")
                     }
                 }
             } catch let error {
@@ -60,6 +60,7 @@ public final class LiSDKManager {
     /// Returns the singleton instance of `LiSDKManager`.
     public static let sharedInstance = LiSDKManager()
     public var liAuthState: LiAuthState = LiAuthState()
+    public let clientManager: LiClientManager = LiClientManager()
     /**
      This function should used to get response_limit and discussion_style set by admin from the community server.
      */

--- a/LiCoreSDK/Models/LiClientRequestParams.swift
+++ b/LiCoreSDK/Models/LiClientRequestParams.swift
@@ -355,7 +355,7 @@ public struct LiDeviceIdFetchClientRequestParams: LiClientRequestParams {
         self.pushNotificationProvider = pushNotificationProvider.rawValue
     }
     public func getPostParams() -> [String: Any] {
-        let params: [String: Any] = ["type": LiQueryConstant.ResponseType.liUserDeviceIdFetchType, "device_id": deviceId, "client_id": LiSDKManager.sharedInstance.liAppCredentials.clientId, "push_notification_provider": pushNotificationProvider, "application_type": LiQueryConstant.ResponseType.liApplicationType]
+        let params: [String: Any] = ["type": LiQueryConstant.ResponseType.liUserDeviceIdFetchType, "device_id": deviceId, "client_id": LiSDKManager.shared().liAppCredentials.clientId, "push_notification_provider": pushNotificationProvider, "application_type": LiQueryConstant.ResponseType.liApplicationType]
         return params
     }
     public enum NotificationProviders: String {

--- a/LiCoreSDK/Networking/LiClient.swift
+++ b/LiCoreSDK/Networking/LiClient.swift
@@ -135,7 +135,7 @@ extension LiClient {
         case .refreshAccessToken:
             return "/auth/v1/refreshToken"
         case .liSSOTokenRequest:
-            return "/" + LiSDKManager.sharedInstance.liAppCredentials.tenantID + "/api/2.0/auth/authorize"
+            return "/" + LiSDKManager.shared().liAppCredentials.tenantID + "/api/2.0/auth/authorize"
         case .liKudoClient(let requestParams):
             return "/messages/" + requestParams.messageId  + "/kudos"
         case .liUploadImageClient:
@@ -201,14 +201,14 @@ extension LiClient {
         }
     }
     internal var headers: HTTPHeaders {
-        let clientID = LiSDKManager.sharedInstance.liAppCredentials.clientId
-        let clientAppName = LiSDKManager.sharedInstance.liAppCredentials.clientAppName
-        let accessToken = LiSDKManager.sharedInstance.liAuthState.accessToken
+        let clientID = LiSDKManager.shared().liAppCredentials.clientId
+        let clientAppName = LiSDKManager.shared().liAppCredentials.clientAppName
+        let accessToken = LiSDKManager.shared().liAuthState.accessToken
         var headers: [String: String]
-        let visitorId = LiSDKManager.sharedInstance.visitorId ?? ""
+        let visitorId = LiSDKManager.shared().visitorId ?? ""
         switch self {
         case .getAccessToken, .refreshAccessToken, .liSSOTokenRequest, .liMessagesClient, .liRepliesClient, .liKudoClient, .liUploadImageClient, .liCreateReplyClient, .liSearchClient, .liNoLiqlClient, .liCategoryClient, .liBoardsByDepthClient, .liCategoryBoardsClient, .liMessagesByBoardIdClient, .liFloatedMessagesClient, .liCreateMessageClient, .liSdkSettingsClient, .liUserSubscriptionsClient, .liUserMessagesClient, .liUserDetailsClient, .liMessageClient, .liMessagesByIdsClient, .liAcceptSolutionClient, .liReportAbuseClient, .liDeviceIdFetchClient, .liCreateUserClient, .liSubscriptionPostClient, .liSubscriptionDeleteClient, .liMarkMessagePostClient, .liMarkMessagesPostClient, .liMarkTopicPostClient, .liUpdateMessageClient, .liUpdateUserClient, .liDeviceIdUpdateClient, .liGenericGetClient, .liGenericDeleteClient, .liMessageDeleteClient, .liUnKudoClient:
-            if LiSDKManager.sharedInstance.liAuthManager.isUserLoggedIn() {
+            if LiSDKManager.shared().liAuthManager.isUserLoggedIn() {
                 headers = ["client-id": clientID, "Authorization": "Bearer " + (accessToken ?? ""), "Visitor-Id": visitorId, "Application-Identifier": clientAppName, "Application-Version": LiQueryConstant.apiVersion, "Content-Type": "application/json"]
             } else {
                 headers = ["client-id": clientID, "Visitor-Id": visitorId, "Application-Identifier": clientAppName, "Application-Version": LiQueryConstant.apiVersion, "Content-Type": "application/json"]
@@ -224,24 +224,24 @@ extension LiClient {
                 headers.update(other: additionalHttpHeaders)
             }
         case .liBeaconClient:
-            if LiSDKManager.sharedInstance.liAuthManager.isUserLoggedIn() {
+            if LiSDKManager.shared().liAuthManager.isUserLoggedIn() {
                 headers = ["client-id": clientID, "Authorization": "Bearer " + (accessToken ?? ""), "Visitor-Id": visitorId, "Application-Identifier": clientAppName, "Application-Version": LiQueryConstant.apiVersion, "Content-Type": "application/json"]
             } else {
                 headers = ["client-id": clientID, "Visitor-Id": visitorId, "Application-Identifier": clientAppName, "Application-Version": LiQueryConstant.apiVersion, "Content-Type": "application/json"]
             }
-            if let visitLastIssueTime = LiSDKManager.sharedInstance.liAuthState.visitLastIssueTime {
+            if let visitLastIssueTime = LiSDKManager.shared().liAuthState.visitLastIssueTime {
                 headers["Visit-Last-Issue-Time"] = visitLastIssueTime
             }
-            if let visitOriginTime = LiSDKManager.sharedInstance.liAuthState.visitOriginTime {
+            if let visitOriginTime = LiSDKManager.shared().liAuthState.visitOriginTime {
                 headers["Visit-Origin-Time"] = visitOriginTime
             }
         }
         return headers
     }
     internal var parameters: Parameters? {
-        let clientID =  LiSDKManager.sharedInstance.liAppCredentials.clientId
-        let clientSecret = LiSDKManager.sharedInstance.liAppCredentials.clientSecret
-        let redirectUri = LiSDKManager.sharedInstance.liAppCredentials.redirectURL
+        let clientID =  LiSDKManager.shared().liAppCredentials.clientId
+        let clientSecret = LiSDKManager.shared().liAppCredentials.clientSecret
+        let redirectUri = LiSDKManager.shared().liAppCredentials.redirectURL
         switch self {
         case .getAccessToken(let code):
             return ["code": code,
@@ -250,7 +250,7 @@ extension LiClient {
                     "client_secret": clientSecret,
                     "grant_type": "authorization_code"]
         case .refreshAccessToken:
-            let refreshToken = LiSDKManager.sharedInstance.liAuthState.refreshToken
+            let refreshToken = LiSDKManager.shared().liAuthState.refreshToken
             return ["refresh_token": refreshToken ?? "",
                     "client_id": clientID,
                     "client_secret": clientSecret,

--- a/LiCoreSDK/Networking/LiNetworkUtils.swift
+++ b/LiCoreSDK/Networking/LiNetworkUtils.swift
@@ -17,21 +17,21 @@ struct LiUrlConstructor {
     static func getBaseURL(client: LiClient) -> String {
         let clientName: String
         let apiProxyHost: String
-        if let tenantId = LiSDKManager.sharedInstance.liAuthState.tenantId {
+        if let tenantId = LiSDKManager.shared().liAuthState.tenantId {
             clientName = tenantId
         } else {
-            clientName = LiSDKManager.sharedInstance.liAppCredentials.tenantID
+            clientName = LiSDKManager.shared().liAppCredentials.tenantID
         }
-        if let apiProxy = LiSDKManager.sharedInstance.liAuthState.apiProxyHost {
+        if let apiProxy = LiSDKManager.shared().liAuthState.apiProxyHost {
             apiProxyHost = apiProxy
         } else {
-            apiProxyHost = LiSDKManager.sharedInstance.liAppCredentials.apiProxyHost
+            apiProxyHost = LiSDKManager.shared().liAppCredentials.apiProxyHost
         }
         switch client {
         case .liUploadImageClient, .liCreateReplyClient, .liKudoClient, .liBeaconClient, .liNoLiqlClient, .liMessagesClient, .liRepliesClient, .liSearchClient, .liCategoryClient, .liBoardsByDepthClient, .liCategoryBoardsClient, .liMessagesByBoardIdClient, .liFloatedMessagesClient, .liCreateMessageClient, .liSdkSettingsClient, .liUserSubscriptionsClient, .liUserMessagesClient, .liUserDetailsClient, .liMessageClient, .liMessagesByIdsClient, .liAcceptSolutionClient, .liReportAbuseClient, .liDeviceIdFetchClient, .liCreateUserClient, .liSubscriptionPostClient, .liSubscriptionDeleteClient, .liMarkMessagePostClient, .liMarkMessagesPostClient, .liMarkTopicPostClient, .liUpdateMessageClient, .liUpdateUserClient, .liGenericPutClient, .liGenericPostClient, .liDeviceIdUpdateClient, .liGenericGetClient, .liGenericDeleteClient, .liMessageDeleteClient, .liUnKudoClient:
             return "https://" + apiProxyHost + "/community/2.0/" + clientName
         case .liSSOTokenRequest:
-            return LiSDKManager.sharedInstance.liAppCredentials.communityURL
+            return LiSDKManager.shared().liAppCredentials.communityURL
         case .getAccessToken, .refreshAccessToken:
             return "https://" + apiProxyHost
         }

--- a/LiCoreSDK/Networking/LiRestClient.swift
+++ b/LiCoreSDK/Networking/LiRestClient.swift
@@ -35,10 +35,10 @@ class LiRestClient {
                             if let path = response.request?.url?.path.contains("becon") {
                                 if path {
                                     if let visitLastIssueTime = response.response?.allHeaderFields["Visit-Last-Issue-Time"] as? String {
-                                        LiSDKManager.sharedInstance.liAuthState.set(visitLastIssueTime: visitLastIssueTime)
+                                        LiSDKManager.shared().liAuthState.set(visitLastIssueTime: visitLastIssueTime)
                                     }
                                     if let visitOriginTime = response.response?.allHeaderFields["Visit-Origin-Time"] as? String {
-                                        LiSDKManager.sharedInstance.liAuthState.set(visitOriginTime: visitOriginTime)
+                                        LiSDKManager.shared().liAuthState.set(visitOriginTime: visitOriginTime)
                                     }
                                 }
                             }
@@ -72,7 +72,7 @@ class LiRestClient {
     private func accessToken <T: Router> (client: T, isValid: @escaping (Bool, Error?) -> Void) {
 //        isValid(true, nil)
 //        return
-        if !LiSDKManager.sharedInstance.liAuthManager.isUserLoggedIn() {
+        if !LiSDKManager.shared().liAuthManager.isUserLoggedIn() {
             isValid(true, nil)
         } else {
             if isAccessTokenValid() {
@@ -81,11 +81,11 @@ class LiRestClient {
                 oauthHandler.refreshTokens(completion: { succeeded, accessToken, refreshToken, expiresIn, error in
                     if succeeded {
                         if let accessToken = accessToken, let refreshToken = refreshToken, let expiresIn = expiresIn {
-                            LiSDKManager.sharedInstance.liAuthState.set(accessToken: accessToken)
-                            LiSDKManager.sharedInstance.liAuthState.set(refreshToken: refreshToken)
+                            LiSDKManager.shared().liAuthState.set(accessToken: accessToken)
+                            LiSDKManager.shared().liAuthState.set(refreshToken: refreshToken)
                             let currentDate = NSDate()
                             let newDate = NSDate(timeInterval: expiresIn, since: currentDate as Date)
-                            LiSDKManager.sharedInstance.liAuthState.set(expiryDate: newDate)
+                            LiSDKManager.shared().liAuthState.set(expiryDate: newDate)
                         }
                         isValid(true, nil)
                     } else {
@@ -97,7 +97,7 @@ class LiRestClient {
     }
     private func isAccessTokenValid() -> Bool {
         let todaysDate = NSDate()
-        if let waitingDate: NSDate = LiSDKManager.sharedInstance.liAuthState.expiryDate {
+        if let waitingDate: NSDate = LiSDKManager.shared().liAuthState.expiryDate {
             if todaysDate.compare(waitingDate as Date) == ComparisonResult.orderedDescending {
                 return false
             } else {

--- a/LiCoreSDK/Networking/SSOHandler.swift
+++ b/LiCoreSDK/Networking/SSOHandler.swift
@@ -40,11 +40,11 @@ class SSOHandler: RequestRetrier {
                             return
                         }
                         if let accessToken = accessToken, let refreshToken = refreshToken, let expiresIn = expiresIn {
-                            LiSDKManager.sharedInstance.liAuthState.set(accessToken: accessToken)
-                            LiSDKManager.sharedInstance.liAuthState.set(refreshToken: refreshToken)
+                            LiSDKManager.shared().liAuthState.set(accessToken: accessToken)
+                            LiSDKManager.shared().liAuthState.set(refreshToken: refreshToken)
                             let currentDate = NSDate()
                             let newDate = NSDate(timeInterval: expiresIn, since: currentDate as Date)
-                            LiSDKManager.sharedInstance.liAuthState.set(expiryDate: newDate)
+                            LiSDKManager.shared().liAuthState.set(expiryDate: newDate)
                         }
                         strongSelf.requestsToRetry.forEach { $0(succeeded, 0.0) }
                         strongSelf.requestsToRetry.removeAll()

--- a/LiCoreSDK/Notification/LiNotificationManager.swift
+++ b/LiCoreSDK/Notification/LiNotificationManager.swift
@@ -27,7 +27,7 @@ public struct LiNotificationManager {
         let requestParams = try! LiDeviceIdFetchClientRequestParams(deviceId: deviceToken, pushNotificationProvider: notificationProvider)
         LiRestClient.sharedInstance.request(client: LiClient.liDeviceIdFetchClient(requestParams: requestParams), success: { (response: LiBaseResponse) in
             if let notificationId = response.data["id"] as? String {
-                LiSDKManager.sharedInstance.liAuthState.set(notificationId: notificationId)
+                LiSDKManager.shared().liAuthState.set(notificationId: notificationId)
             }
         }) { (error : Error) in
             print("Failed to update device token: - \(error)")
@@ -39,7 +39,7 @@ public struct LiNotificationManager {
      */
     public static func update(deviceToken: String) {
         //TODO: - get notificationId
-        let id = LiSDKManager.sharedInstance.liAuthState.notificationId ?? ""
+        let id = LiSDKManager.shared().liAuthState.notificationId ?? ""
         let requestParams = try! LiDeviceIdUpdateClientRequestParams(deviceId: deviceToken, id: id)
         LiRestClient.sharedInstance.request(client: LiClient.liDeviceIdUpdateClient(requestParams: requestParams), success: { (_: LiBaseResponse) in
         }) { (error: Error) in

--- a/LiCoreSDK/Utils/LiUtils.swift
+++ b/LiCoreSDK/Utils/LiUtils.swift
@@ -47,12 +47,20 @@ struct LiUtils {
     }
     static func emailValidation(email: String) throws -> String {
         let emailRegEx = "(?:[a-z0-9!#$%\\&'*+/=?\\^_`{|}~-]+(?:\\.[a-z0-9!#$%\\&'*+/=?\\^_`{|}"+"~-]+)*|\"(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21\\x23-\\x5b\\x5d-\\"+"x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])*\")@(?:(?:[a-z0-9](?:[a-"+"z0-9-]*[a-z0-9])?\\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\\[(?:(?:25[0-5"+"]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-"+"9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21"+"-\\x5a\\x53-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])+)\\])"
-        
         let emailTest = NSPredicate(format:"SELF MATCHES[c] %@", emailRegEx)
         if emailTest.evaluate(with: email) {
             return email
         } else {
             throw LiError.invalidArgument(errorMessage: "Invalid email format.")
+        }
+    }
+    static func urlValidation(url: String, message: String) throws -> String {
+        let regEx = "((https|http)://)((\\w|-)+)(([.]|[/])((\\w|-)+))+"
+        let predicate = NSPredicate(format:"SELF MATCHES %@", argumentArray:[regEx])
+        if predicate.evaluate(with: url) {
+            return url
+        } else {
+            throw LiError.invalidArgument(errorMessage: message)
         }
     }
 }

--- a/LiCoreSDKTests/LiAppCredentialsTests.swift
+++ b/LiCoreSDKTests/LiAppCredentialsTests.swift
@@ -1,0 +1,76 @@
+//
+//  LiAppCredentialsTests.swift
+//  LiCoreSDKTests
+//
+//  Created by Shekhar Dahore on 3/26/18.
+//  Copyright © 2018 Shekhar Dahore. All rights reserved.
+//
+
+import Quick
+import Nimble
+@testable import LiCoreSDK
+
+class LiAppCredentialsTests: QuickSpec {
+    override func spec() {
+        describe("LiAppCredentials") {
+            context("Setting up with proper credentials") {
+                it("Should not throw error") {
+                    expect { try LiAppCredentials(clientId: "a", clientSecret: "a", communityURL: "https://google.com", tenantID: "a", apiProxyHost: "a", clientAppName: "a")}.toNot( throwError() )
+                }
+            }
+            context("Setting up credentials with empty clientId") {
+                it("Should throw error") {
+                    expect { try LiAppCredentials(clientId: "", clientSecret: "a", communityURL: "https://google.com", tenantID: "a", apiProxyHost: "a", clientAppName: "a")}.to( throwError() )
+                }
+            }
+            context("Setting up credentials with empty clientSecret") {
+                it("Should throw error") {
+                    expect { try LiAppCredentials(clientId: "a", clientSecret: "", communityURL: "https://google.com", tenantID: "a", apiProxyHost: "a", clientAppName: "a")}.to( throwError() )
+                }
+            }
+            context("Setting up credentials with empty communityURL") {
+                it("Should throw error") {
+                    expect { try LiAppCredentials(clientId: "a", clientSecret: "a", communityURL: "", tenantID: "a", apiProxyHost: "a", clientAppName: "a")}.to( throwError() )
+                }
+            }
+            context("Setting up credentials with empty tenantID") {
+                it("Should throw error") {
+                    expect { try LiAppCredentials(clientId: "a", clientSecret: "a", communityURL: "https://google.com", tenantID: "", apiProxyHost: "a", clientAppName: "a")}.to( throwError() )
+                }
+            }
+            context("Setting up credentials with empty apiProxyHost") {
+                it("Should throw error") {
+                    expect { try LiAppCredentials(clientId: "a", clientSecret: "a", communityURL: "https://google.com", tenantID: "a", apiProxyHost: "", clientAppName: "a")}.to( throwError() )
+                }
+            }
+            context("Setting up credentials with empty clientAppName") {
+                it("Should throw error") {
+                    expect { try LiAppCredentials(clientId: "a", clientSecret: "a", communityURL: "https://google.com", tenantID: "a", apiProxyHost: "a", clientAppName: "")}.to( throwError() )
+                }
+            }
+            context("Setting up credentials with invalid communityURL") {
+                it("Should throw error") {
+                    expect { try LiAppCredentials(clientId: "a", clientSecret: "a", communityURL: "http//google.com", tenantID: "a", apiProxyHost: "a", clientAppName: "a")}.to( throwError() )
+                }
+            }
+            context("Setting up credentials with invalid communityURL") {
+                it("Should throw error") {
+                    expect { try LiAppCredentials(clientId: "a", clientSecret: "a", communityURL: "google.com", tenantID: "a", apiProxyHost: "a", clientAppName: "a")}.to( throwError() )
+                }
+            }
+        }
+        
+        describe("LiAppCredentials") {
+            let appCred = try! LiAppCredentials(clientId: "12jasj32nnds", clientSecret: "121fa322dsds", communityURL: "https://google.com", tenantID: "game223", apiProxyHost: "com.api.proxy", clientAppName: "test")
+            context("get URL that initiates lithium login") {
+                var url: URLRequest?
+                it("url should match") {
+                    expect { url = try appCred.getURL() }.toNot(throwError())
+                    expect(url?.url?.absoluteString.contains("https://google.com/auth/oauth2/authorize?client_id=12jasj32nnds&redirect_uri=com.google%3A//oauth2callback&response_type=code&state=")).to(beTruthy())
+                }
+            }
+        }
+    }
+    public func testDummy() {}
+}
+

--- a/LiCoreSDKTests/LiSDKManagerTests.swift
+++ b/LiCoreSDKTests/LiSDKManagerTests.swift
@@ -1,0 +1,31 @@
+//
+//  LiSDKManagerTests.swift
+//  LiCoreSDKTests
+//
+//  Created by Shekhar Dahore on 3/23/18.
+//  Copyright © 2018 Shekhar Dahore. All rights reserved.
+//
+
+import Quick
+import Nimble
+@testable import LiCoreSDK
+
+class LiSDKManagerTests: QuickSpec {
+    override func spec() {
+        let cred = try! LiAppCredentials(clientId: "a", clientSecret: "a", communityURL: "a", tenantID: "a", apiProxyHost: "a", clientAppName: "a")
+        describe("LiSDKManager") {
+            LiSDKManager.setup(credentials: cred)
+            context("Calling setup before using shared instance") {
+                it("Should not throw error") {
+                    expect { LiSDKManager.shared() }.toNot( throwError() )
+                }
+            }
+            context("Calling Visitor Id after setup") {
+                it("should not be nil") {
+                    expect { LiSDKManager.shared().visitorId }.toNot(beNil())
+                }
+            }
+        }
+    }
+    public func testDummy() {}
+}


### PR DESCRIPTION
Changelog
1. LiClientManage is now a property of LiSDKManager and thus an instance of LiSDKManager is now required to make API calls.
2. LiSDKManger now takes the LiAppCredentials object as a parameter of setup method, instead of taking them from info.plist.
